### PR TITLE
Typo fix in propertyFieldSearch import

### DIFF
--- a/solutions/LinksAndHandlebarsTemplate/src/webparts/handlebarTemplateDisplay/HandlebarTemplateDisplayWebPart.ts
+++ b/solutions/LinksAndHandlebarsTemplate/src/webparts/handlebarTemplateDisplay/HandlebarTemplateDisplayWebPart.ts
@@ -21,7 +21,7 @@ import { IHandlebarTemplateDisplayWebPartProps } from './IHandlebarTemplateDispl
 import { PropertyFieldCamlQueryFieldMapping, PropertyFieldCamlQueryOrderBy } from "../../propertyPane/propertyFieldCamlQueryFieldMapping/PropertyFieldCamlQueryFieldMapping";
 import QueryStringParser from "../../utilities/urlparser/queryStringParser";
 import pnp, { SearchQueryBuilder, Sort, SearchProperty } from 'sp-pnp-js';
-import { PropertyPaneSearch } from '../../propertyPane/propertyPaneSearch/PropertyFieldSearch';
+import { PropertyPaneSearch } from '../../propertyPane/PropertyPaneSearch/PropertyFieldSearch';
 import { WebPartLogger } from '../../utilities/webpartlogger/usagelogger';
 
 export default class HandlebarTemplateDisplayWebPart extends BaseClientSideWebPart<IHandlebarTemplateDisplayWebPartProps> {


### PR DESCRIPTION
Typo in import.

| Q               | A
| --------------- | ---
| Bug fix?        |  yes
| New feature?    | no
| New sample?      | no
| Related issues?  | fixes #39 

#### What's in this Pull Request?

Fixing casing on import of propertyFieldSearch