### PR TITLE
fix: custom search box placeholder text not shown when autocomplete is on

### DIFF
--- a/solutions/ModernSearch/react-search-refiners/spfx/src/webparts/searchBox/components/SearchBoxContainer.tsx
+++ b/solutions/ModernSearch/react-search-refiners/spfx/src/webparts/searchBox/components/SearchBoxContainer.tsx
@@ -54,7 +54,7 @@ export default class SearchBoxContainer extends React.Component<ISearchBoxContai
           <div>
             <div className={ styles.searchFieldGroup }>
               <TextField {...getInputProps({
-                  placeholder: strings.SearchInputPlaceholder,
+                  placeholder: this.props.placeholderText ? this.props.placeholderText : strings.SearchInputPlaceholder,
                   onKeyDown: event => {
 
                     // Submit search on "Enter" 


### PR DESCRIPTION

| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| New sample?      | no
| Related issues?  | none I know of

#### What's in this Pull Request?

When switching on autocomplete for the search box the custom placeholder text is not applied, but a static placeholder. This is a fix.