### PR TITLE
[ModernSearch] Fixed regressions: empty paging & focus on changing page

### DIFF
--- a/solutions/ModernSearch/react-search-refiners/spfx/config/package-solution.json
+++ b/solutions/ModernSearch/react-search-refiners/spfx/config/package-solution.json
@@ -3,7 +3,7 @@
   "solution": {
     "name": "PnP - Search Web Parts",
     "id": "890affef-33e0-4d72-bd72-36399e02143b",
-    "version": "3.0.1.0",
+    "version": "3.0.2.0",
     "includeClientSideAssets": true,
     "skipFeatureDeployment": false,
     "isDomainIsolated": false

--- a/solutions/ModernSearch/react-search-refiners/spfx/package.json
+++ b/solutions/ModernSearch/react-search-refiners/spfx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pnp-react-search-refiners",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "private": true,
   "engines": {
     "node": ">=0.10.0"

--- a/solutions/ModernSearch/react-search-refiners/spfx/src/webparts/searchPagination/SearchPaginationWebPart.ts
+++ b/solutions/ModernSearch/react-search-refiners/spfx/src/webparts/searchPagination/SearchPaginationWebPart.ts
@@ -4,7 +4,6 @@ import { Version, DisplayMode } from '@microsoft/sp-core-library';
 import {
   BaseClientSideWebPart,
   IPropertyPaneConfiguration,
-  IPropertyPaneDropdownOption,
   PropertyPaneDropdown
 } from '@microsoft/sp-webpart-base';
 
@@ -27,12 +26,12 @@ export default class SearchPaginationWebPart extends BaseClientSideWebPart<ISear
   private _pageInformation: DynamicProperty<ISearchResultSourceData>;
 
   public render(): void {
-    let renderElement = null;
     let searchPagination: IPaginationInformation = null;
 
+    let renderElement: JSX.Element = React.createElement('div', null);
     if (this.properties.searchResultsDataSourceReference) {
 
-      // If the dynamic property exists, it means the Web Part ins connected to a search results Web Part
+      // If the dynamic property exists, it means the Web Part is connected to a search results Web Part
       if (this._pageInformation) {
         const searchResultSourceData: ISearchResultSourceData = this._pageInformation.tryGetValue();
 
@@ -41,7 +40,7 @@ export default class SearchPaginationWebPart extends BaseClientSideWebPart<ISear
         }
       }      
 
-      if (searchPagination)
+      if (searchPagination && searchPagination.TotalRows > 0)
       {
         this._currentPage = searchPagination.CurrentPage;
         renderElement = React.createElement(
@@ -57,20 +56,19 @@ export default class SearchPaginationWebPart extends BaseClientSideWebPart<ISear
           }
         );
       }
-    } else {
+    }
+    else {
       if (this.displayMode === DisplayMode.Edit) {
-          renderElement = React.createElement(
-            Placeholder,
-            {
-                iconName: strings.PlaceHolderEditLabel,
-                iconText: strings.PlaceHolderIconText,
-                description: strings.PlaceHolderDescription,
-                buttonLabel: strings.PlaceHolderConfigureBtnLabel,
-                onConfigure: this._setupWebPart.bind(this)
-            }
-          );
-      } else {
-          renderElement = React.createElement('div', null);
+        renderElement = React.createElement(
+          Placeholder,
+          {
+              iconName: strings.PlaceHolderEditLabel,
+              iconText: strings.PlaceHolderIconText,
+              description: strings.PlaceHolderDescription,
+              buttonLabel: strings.PlaceHolderConfigureBtnLabel,
+              onConfigure: this._setupWebPart.bind(this)
+          }
+        );
       }
     }
     ReactDom.render(renderElement, this.domElement);

--- a/solutions/ModernSearch/react-search-refiners/spfx/src/webparts/searchResults/components/SearchResultsContainer/SearchResultsContainer.tsx
+++ b/solutions/ModernSearch/react-search-refiners/spfx/src/webparts/searchResults/components/SearchResultsContainer/SearchResultsContainer.tsx
@@ -207,6 +207,7 @@ export default class SearchResultsContainer extends React.Component<ISearchResul
 
     public async componentWillReceiveProps(nextProps: ISearchResultsContainerProps) {
         let executeSearch = false;
+        let isPageChanged = false;
         let selectedPage = 1;
         let lastSelectedProperties = (this.props.searchService.selectedProperties) ? this.props.searchService.selectedProperties.join(',') : undefined;
         let lastQuery = this.props.queryKeywords + this.props.searchService.queryTemplate + lastSelectedProperties;
@@ -215,6 +216,7 @@ export default class SearchResultsContainer extends React.Component<ISearchResul
 
         if (this.props.selectedPage !== nextProps.selectedPage) {
             executeSearch = true;
+            isPageChanged = true;
             selectedPage = nextProps.selectedPage;
         }
 
@@ -229,6 +231,7 @@ export default class SearchResultsContainer extends React.Component<ISearchResul
             || this.props.queryKeywords !== nextProps.queryKeywords
             || this.props.enableLocalization !== nextProps.enableLocalization) {
             executeSearch = true;
+            isPageChanged = false;
             selectedPage = 1;
             if (lastQuery !== query) {
                 nextProps.searchService.refinementFilters = [];
@@ -245,6 +248,12 @@ export default class SearchResultsContainer extends React.Component<ISearchResul
                         hasError: false,
                         errorMessage: ""
                     });
+
+                    if (isPageChanged)
+                    {
+                        // Set the focus at the top of the component
+                        this._searchWpRef.focus();
+                    }
 
                     // We reset the page number and refinement filters
                     const searchResults = await nextProps.searchService.search(nextProps.queryKeywords, selectedPage);


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| New sample?      | no
| Related issues?  | fixes https://github.com/SharePoint/sp-dev-solutions/pull/73#issuecomment-472690343

#### What's in this Pull Request?
- Fixed regression: focus set on top of results when changing pages
- Fixed issue where page component shows even if there are no results
- Bumped version number