### PR TITLE
return existing SearchService from getSearchService

### DIFF
--- a/solutions/ModernSearch/react-search-refiners/spfx/src/webparts/searchResults/SearchResultsWebPart.ts
+++ b/solutions/ModernSearch/react-search-refiners/spfx/src/webparts/searchResults/SearchResultsWebPart.ts
@@ -1161,6 +1161,6 @@ export default class SearchResultsWebPart extends BaseClientSideWebPart<ISearchR
     }
 
     private getSearchService(): ISearchService {
-        return (Environment.type === EnvironmentType.Local) ? new MockSearchService() : new SearchService(this.context);
+        return (Environment.type === EnvironmentType.Local) ? new MockSearchService() : this._searchService || new SearchService(this.context);
     }
 }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| New sample?      | no

#### What's in this Pull Request?

In SearchResultsWebPart, I was seeing that many times on the first page load the queryTemplate was not getting applied. It seems like this commit 
https://github.com/SharePoint/sp-dev-solutions/commit/f5177c2567da100945971b1913e4bc08cd2227ff changed it so the SearchService could get newed up multiple times because its now in render(). I made getSearchService return the existing instance instead of creating a new one every render().



