### PR TITLE
[ModernSearch] No SearchService instantion on render()

### DIFF
--- a/solutions/ModernSearch/react-search-refiners/README.md
+++ b/solutions/ModernSearch/react-search-refiners/README.md
@@ -1,6 +1,6 @@
 # SharePoint Framework modern search Web Parts
 
-![Version](https://img.shields.io/badge/version-3.0.3-green.svg)
+![Version](https://img.shields.io/badge/version-3.0.5-green.svg)
 
 ## Summary
 This solution allows you to build user friendly SharePoint search experiences using SPFx in the modern interface. The main features include:
@@ -379,6 +379,7 @@ Version|Date|Comments
 3.0.2.0 | Mar 14, 2019 | Fixed regressions with the paging experience
 3.0.3.0 | Mar 16, 2019 | Fixed display of custom renderers, in edit mode
 3.0.4.0 | Mar 21, 2019 | Fixed loading of Handlebars helpers when having multiple search parts on a page
+3.0.5.0 | Mar 26, 2019 | Fixed recreating SearchService on each render
 
 ## Important notice on upgrading the solution from pre v2.2.0.0
 **Due to code restucturing we have hit an edge case which impacts upgrades from previous versions. To solve the issue go to `https://<tenant>.sharepoint.com/sites/<appcatalog>/Lists/ComponentManifests` and remove the entries for SearchBox and Search Results, and then upload the .sppkg for the new release.**

--- a/solutions/ModernSearch/react-search-refiners/spfx/config/package-solution.json
+++ b/solutions/ModernSearch/react-search-refiners/spfx/config/package-solution.json
@@ -3,7 +3,7 @@
   "solution": {
     "name": "PnP - Search Web Parts",
     "id": "890affef-33e0-4d72-bd72-36399e02143b",
-    "version": "3.0.4.0",
+    "version": "3.0.5.0",
     "includeClientSideAssets": true,
     "skipFeatureDeployment": false,
     "isDomainIsolated": false

--- a/solutions/ModernSearch/react-search-refiners/spfx/package.json
+++ b/solutions/ModernSearch/react-search-refiners/spfx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pnp-react-search-refiners",
-  "version": "3.0.4",
+  "version": "3.0.5",
   "private": true,
   "engines": {
     "node": ">=0.10.0"

--- a/solutions/ModernSearch/react-search-refiners/spfx/src/webparts/searchResults/SearchResultsWebPart.ts
+++ b/solutions/ModernSearch/react-search-refiners/spfx/src/webparts/searchResults/SearchResultsWebPart.ts
@@ -82,7 +82,6 @@ export default class SearchResultsWebPart extends BaseClientSideWebPart<ISearchR
 
     public async render(): Promise<void> {
         // Configure the provider before the query according to our needs
-        this._searchService = this.getSearchService();
         this._searchService.resultsCount = this.properties.maxResultsCount;
         this._searchService.queryTemplate = await this.replaceQueryVariables(this.properties.queryTemplate);
         this._searchService.resultSourceId = this.properties.resultSourceId;
@@ -441,6 +440,8 @@ export default class SearchResultsWebPart extends BaseClientSideWebPart<ISearchR
                 this.properties.externalTemplateUrl = '';
             }
         }
+
+        this._searchService = this.getSearchService();
     }
 
     protected async onPropertyPaneConfigurationStart() {

--- a/solutions/ModernSearch/react-search-refiners/spfx/src/webparts/searchResults/SearchResultsWebPart.ts
+++ b/solutions/ModernSearch/react-search-refiners/spfx/src/webparts/searchResults/SearchResultsWebPart.ts
@@ -52,6 +52,7 @@ import IRefinerConfiguration from '../../models/IRefinerConfiguration';
 import { SearchComponentType } from '../../models/SearchComponentType';
 import ISearchResultSourceData from '../../models/ISearchResultSourceData';
 import IPaginationSourceData from '../../models/IPaginationSourceData';
+import * as update from 'immutability-helper';
 
 const LOG_SOURCE: string = '[SearchResultsWebPart_{0}]';
 
@@ -69,6 +70,7 @@ export default class SearchResultsWebPart extends BaseClientSideWebPart<ISearchR
     private _paginationSourceData: DynamicProperty<IPaginationSourceData>;
     private _codeRenderers: IRenderer[];
     private _searchContainer : JSX.Element;
+    private _queryTemplate: string;
 
     /**
      * The template to display at render time
@@ -81,13 +83,7 @@ export default class SearchResultsWebPart extends BaseClientSideWebPart<ISearchR
     }
 
     public async render(): Promise<void> {
-        // Configure the provider before the query according to our needs
-        this._searchService.resultsCount = this.properties.maxResultsCount;
-        this._searchService.queryTemplate = await this.replaceQueryVariables(this.properties.queryTemplate);
-        this._searchService.resultSourceId = this.properties.resultSourceId;
-        this._searchService.sortList = this._convertToSortList(this.properties.sortList);
-        this._searchService.enableQueryRules = this.properties.enableQueryRules;
-        this._searchService.selectedProperties = this.properties.selectedProperties ? this.properties.selectedProperties.replace(/\s|,+$/g, '').split(',') : [];
+        this._queryTemplate = await this.replaceQueryVariables(this.properties.queryTemplate);
 
         // Determine the template content to display
         // In the case of an external template is selected, the render is done asynchronously waiting for the content to be fetched
@@ -126,8 +122,17 @@ export default class SearchResultsWebPart extends BaseClientSideWebPart<ISearchR
             }
         }
 
-        this._searchService.refiners = refinerConfiguration;
-        this._searchService.refinementFilters = selectedFilters;
+        // Configure the provider before the query according to our needs
+        this._searchService = update(this._searchService, {
+            resultsCount: {$set: this.properties.maxResultsCount},
+            queryTemplate: {$set: this._queryTemplate},
+            resultSourceId: {$set: this.properties.resultSourceId},
+            sortList: {$set: this._convertToSortList(this.properties.sortList)},
+            enableQueryRules: {$set: this.properties.enableQueryRules},
+            selectedProperties: {$set: this.properties.selectedProperties ? this.properties.selectedProperties.replace(/\s|,+$/g, '').split(',') : []},
+            refiners: {$set: refinerConfiguration},
+            refinementFilters: {$set: selectedFilters},
+        });
 
         if (this._paginationSourceData) {
             const paginationSourceData: IPaginationSourceData = this._paginationSourceData.tryGetValue();
@@ -440,8 +445,6 @@ export default class SearchResultsWebPart extends BaseClientSideWebPart<ISearchR
                 this.properties.externalTemplateUrl = '';
             }
         }
-
-        this._searchService = this.getSearchService();
     }
 
     protected async onPropertyPaneConfigurationStart() {


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| New sample?      | no
| Related issues?  | fixes #90 

#### What's in this Pull Request?
- Only create search service OnInit
- Use immutability-helper to ensure that componentWillReceiveProps checks keep working, to check when reissuing the search query is necessary