### PR TITLE
Hublinks updates

### DIFF
--- a/solutions/LinksAndHandlebarsTemplate/config/package-solution.json
+++ b/solutions/LinksAndHandlebarsTemplate/config/package-solution.json
@@ -1,9 +1,9 @@
 {
     "$schema": "https://dev.office.com/json-schemas/spfx-build/package-solution.schema.json",
     "solution": {
-        "name": "Sample Hub Web Parts",
+        "name": "Hub Web Parts",
         "id": "520c2090-be2a-4538-b2b0-fd3eeca0cea0",
-        "version": "2.3.0.0",
+        "version": "2.3.2.0",
         "skipFeatureDeployment": true,
         "includeClientSideAssets": true
     },

--- a/solutions/LinksAndHandlebarsTemplate/package.json
+++ b/solutions/LinksAndHandlebarsTemplate/package.json
@@ -1,6 +1,6 @@
 {
     "name": "hub-web-parts",
-    "version": "1.2.0",
+    "version": "2.3.2",
     "private": true,
     "engines": {
         "node": ">=0.10.0"
@@ -14,16 +14,16 @@
         "@microsoft/sp-webpart-base": "1.6.0",
         "@microsoft/sp-lodash-subset": "1.6.0",
         "@microsoft/sp-office-ui-fabric-core": "1.6.0",
-        "@microsoft/sp-http": "~1.6.0",
-        "@microsoft/sp-loader": "~1.6.0",
+        "@microsoft/sp-http": "1.6.0",
+        "@microsoft/sp-loader": "1.6.0",
         "@types/webpack-env": "1.13.1",
         "@types/es6-promise": "0.0.33",
-        "@pnp/spfx-property-controls": "^1.9.0",
-        "deep-diff": "^0.3.8",
-        "handlebars": "^4.0.10",
-        "linqts": "^1.8.2",
-        "npm": "^6.1.0",
-        "sp-pnp-js": "^3.0.7"
+        "@pnp/spfx-property-controls": "1.9.0",
+        "deep-diff": "0.3.8",
+        "handlebars": "4.0.10",
+        "linqts": "1.8.2",
+        "npm": "6.1.0",
+        "sp-pnp-js": "3.0.7"
     },
     "devDependencies": {
         "@microsoft/sp-build-web": "1.6.0",

--- a/solutions/LinksAndHandlebarsTemplate/src/components/LinkPickerPanel/LinkPickerPanel.tsx
+++ b/solutions/LinksAndHandlebarsTemplate/src/components/LinkPickerPanel/LinkPickerPanel.tsx
@@ -59,24 +59,24 @@ export default class LinkPickerPanel
 
           {/* Navigation on left of panel */}
           {this.state.showImageTab &&
-            <Nav initialSelectedKey="site" isOnTop={true}
+            <Nav selectedKey={this.state.navState.toString()} isOnTop={true} initialSelectedKey={NavState.site.toString()} 
             groups={[{
             links:[
               {
                 name: strings.LinkPickerSiteNav,
-                icon:"Globe", key:"site", url:"#",
+                icon:"Globe", key:NavState.site.toString(), url:"#",
                 onClick:this.onSiteNavClick.bind(this),
                 isExpanded: showDocPickerIFrame
               },
               {
                 name: strings.LinkPickerLinkNav,
-                icon:"Link", key:"link", url:"#",
+                icon:"Link", key:NavState.link.toString(), url:"#",
                 onClick:this.onLinkNavClick.bind(this),
                 isExpanded: showLinkEntryForm
               },
               {
                 name: strings.LinkPickerImageNav,
-                icon:"Photo2", key:"image", url:"#",
+                icon:"Photo2", key:NavState.image.toString(), url:"#",
                 onClick:this.onImageNavClick.bind(this),
                 isExpanded: showImageEntryForm
               }
@@ -84,18 +84,18 @@ export default class LinkPickerPanel
             }]}/>
           }
           {!this.state.showImageTab &&
-          <Nav initialSelectedKey="site" isOnTop={true}
+          <Nav selectedKey={this.state.navState.toString()} isOnTop={true} initialSelectedKey={NavState.site.toString()} 
             groups={[{
             links:[
               {
                 name: strings.LinkPickerSiteNav,
-                icon:"Globe", key:"site", url:"#",
+                icon:"Globe", key:NavState.site.toString(), url:"#",
                 onClick:this.onSiteNavClick.bind(this),
                 isExpanded: showDocPickerIFrame
               },
               {
                 name: strings.LinkPickerLinkNav,
-                icon:"Link", key:"link", url:"#",
+                icon:"Link", key:NavState.link.toString(), url:"#",
                 onClick:this.onLinkNavClick.bind(this),
                 isExpanded: showLinkEntryForm
               }
@@ -150,9 +150,17 @@ export default class LinkPickerPanel
   private rejectPickLink: () => void;
 
   // Public method to pick a link
-  public pickLink (): Promise<ILinkPickerChoice> {
+  public pickLink (currentUrl: string = ""): Promise<ILinkPickerChoice> {
+  
+    //set the current url as the optional input url
+    this.setState({
+      url: currentUrl,
+      isUrlValid: this.isValidLink(currentUrl)
+    }, () => {
       this.openLinkPanel();
-      return new Promise<ILinkPickerChoice>(
+    });
+    
+    return new Promise<ILinkPickerChoice>(
           (resolve, reject) => {
               this.resolvePickLink = resolve;
               this.rejectPickLink = reject;
@@ -160,13 +168,16 @@ export default class LinkPickerPanel
   }
 
   private openLinkPanel() {
-      this.addMessageListener();
-      this.setState({
-          isOpen: true,
-          navState: NavState.site,
-          isUrlValid: false,
-          url: ""
-      });
+    //and message listener for document selection iFrame  
+    this.addMessageListener();
+    
+    //set state to open link picker and set proper pane
+    this.setState({
+        isOpen: true,
+        navState: this.state.url ? NavState.link : NavState.site,
+        //isUrlValid: false, //no need to reset the valid state as already set
+        //url: "" //no need to reset the url in state, already set
+    });
   }
 
   private closeLinkPanel() {
@@ -242,7 +253,7 @@ export default class LinkPickerPanel
   }
 
   //Function to return url's of approved images
-  //TODO: allow >1 locaiton of featured images and make configurable
+  //TODO: allow >1 location of featured images and make configurable
   private getApprovedImages(){
     const images: Array<ApprovedImage> = [];
 
@@ -296,9 +307,7 @@ export default class LinkPickerPanel
 
      this.setState(
       {
-        navState: navState,
-        isUrlValid:false,
-        url: ""
+        navState: navState
       }
     );
     return false;

--- a/solutions/LinksAndHandlebarsTemplate/src/propertyPane/propertyFieldCamlQueryFieldMapping/PropertyFieldCamlQueryFieldMappingHost.tsx
+++ b/solutions/LinksAndHandlebarsTemplate/src/propertyPane/propertyFieldCamlQueryFieldMapping/PropertyFieldCamlQueryFieldMappingHost.tsx
@@ -303,7 +303,7 @@ export default class PropertyFieldCamlQueryFieldMappingHost extends React.Compon
 
         switch(field.kind){
           case SPFieldType.Boolean:
-            const val = element.value.toLocaleLowerCase().trim();
+            const val = element.value ? element.value.toLocaleLowerCase().trim() : "false";
             if(element.operator==="Ne")
               conditions.push(CamlBuilder.Expression().BooleanField(element.field).NotEqualTo(val==="yes" || val==="true" || val==="1"));
             else

--- a/solutions/LinksAndHandlebarsTemplate/src/webparts/hubLinks/HubLinksWebPart.ts
+++ b/solutions/LinksAndHandlebarsTemplate/src/webparts/hubLinks/HubLinksWebPart.ts
@@ -282,7 +282,12 @@ export default class HubLinksWebPart extends BaseClientSideWebPart<IHubLinksWebP
   }
 
   public openLinkSelector(event){
-    this.webpart.openLinkPicker(event);
+    var currentUrl: string = "";
+    if (this.activeIndex >= 0 && this.properties.hubLinksItems[this.activeIndex] && this.properties.hubLinksItems[this.activeIndex].URL) {
+      currentUrl = this.properties.hubLinksItems[this.activeIndex].URL;
+    }
+    //open the link picker, sending in the current url for reference
+    this.webpart.openLinkPicker(event, currentUrl);
   }
 
   public itemValidation(length: number, required: boolean, errorText: string, value: string): Promise<string> {
@@ -490,7 +495,9 @@ export default class HubLinksWebPart extends BaseClientSideWebPart<IHubLinksWebP
           {label: strings.ThemePrimaryColor, color: window["__themeState__"]["theme"]["themePrimary"]},
           {label: strings.ThemeSecondaryColor, color: window["__themeState__"]["theme"]["themeSecondary"]},
           {label: strings.ThemePrimaryColor, color: window["__themeState__"]["theme"]["themeTertiary"]},
-          {label: strings.ThemePrimaryText, color: window["__themeState__"]["theme"]["primaryText"]},
+          //primaryText no longer consistent
+          //{label: strings.ThemePrimaryText, color: window["__themeState__"]["theme"]["primaryText"]},
+          {label: strings.ThemePrimaryText, color: window["__themeState__"]["theme"]["bodyText"]},
           {label: strings.WhiteColor, color: window["__themeState__"]["theme"]["white"]},
           {label: strings.BlackColor, color: window["__themeState__"]["theme"]["black"]},          
         ];

--- a/solutions/LinksAndHandlebarsTemplate/src/webparts/hubLinks/components/HubLinks.tsx
+++ b/solutions/LinksAndHandlebarsTemplate/src/webparts/hubLinks/components/HubLinks.tsx
@@ -124,10 +124,12 @@ export default class HubLinks extends React.Component<IHubLinksProps, IHubLinksS
   // ** Event handlers for link picker **
   private linkPickerPanel: LinkPickerPanel;
   // Open the link picker - called from onClick of Change (link) button
-  public openLinkPicker(event){
-    this.linkPickerPanel.pickLink().then(({name, url}) => {
+  public openLinkPicker(event: any, currentUrl: string = ""){
+
+    this.linkPickerPanel.pickLink(currentUrl).then(({name, url}) => {
       this.props.setUrl(url, name);
     });
+
   }
 
   public render(): React.ReactElement<IHubLinksProps> {

--- a/solutions/LinksAndHandlebarsTemplate/src/webparts/hubLinks/components/layouts/GroupedListLayout/BasicGroupedListLayout.tsx
+++ b/solutions/LinksAndHandlebarsTemplate/src/webparts/hubLinks/components/layouts/GroupedListLayout/BasicGroupedListLayout.tsx
@@ -62,7 +62,7 @@ export default class BasicGroupedListLayout implements IHubLinksLayout{
                           <div className={styles["editControls"]}>
                               <DefaultButton iconProps={{iconName:"Clear"}} onClick={this.webpart.deleteBox.bind(this.webpart)} className={styles["right-button"]}/>
                               <DefaultButton iconProps={{iconName:"Edit"}} onClick={this.webpart.editBox.bind(this.webpart)} className={styles["right-button"]}/>
-                              <i className={"ms-Icon ms-Icon--Move "+styles["left-button"]} id="drag-handle" aria-hidden="true"></i>
+                              <i style={{display: "none"}} className={"ms-Icon ms-Icon--Move "+styles["left-button"]} id="drag-handle" aria-hidden="true"></i>
                           </div>
                           }
                         </li>

--- a/solutions/LinksAndHandlebarsTemplate/src/webparts/hubLinks/components/layouts/GroupedListLayout/Styles.module.scss
+++ b/solutions/LinksAndHandlebarsTemplate/src/webparts/hubLinks/components/layouts/GroupedListLayout/Styles.module.scss
@@ -103,6 +103,7 @@
                 background-color: white;
                 border-color: white;
             }
+            /*
             &>i {
                 color: #333333;
                 padding: 5px;
@@ -114,6 +115,21 @@
                 cursor: move;
                 background-color: white;
             }
+            */
+            &>i {
+                color: #333;
+                padding: 5px 5px 0px;
+                font-size: 12px;
+                line-height: 22px;
+                margin: 0px;
+                text-align: right;
+                width: 32px;
+                cursor: move;
+                display: inline-block;
+                box-sizing: border-box;
+                position: relative;
+            }
+            
             & :global .ms-Button.ms-Button--default :global .ms-Button-icon {
                 line-height: 15px;
                 height: 10px;
@@ -169,7 +185,8 @@
             line-height: 18px;
             margin-left: 0;
             list-style-type: none;
-            display: table;
+            box-sizing: border-box;
+            display: block;
             width: 100%;
             & .row {
                 margin: 0;

--- a/solutions/LinksAndHandlebarsTemplate/src/webparts/hubLinks/components/layouts/ListLayout/Styles.module.scss
+++ b/solutions/LinksAndHandlebarsTemplate/src/webparts/hubLinks/components/layouts/ListLayout/Styles.module.scss
@@ -72,6 +72,7 @@
                 background-color: white;
                 border-color: white;
             }
+            /*
             &>i {
                 color: #333333;
                 padding: 5px;
@@ -83,6 +84,18 @@
                 cursor: move;
                 background-color: white;
             }
+            */
+            &>i {
+                padding: 5px 5px 0px;
+                color: #333;
+                font-size: 12px;
+                line-height: 22px;
+                text-align: center;
+                width: 32px;
+                cursor: move;
+                box-sizing: border-box;
+            }
+
             & :global .ms-Button.ms-Button--default :global .ms-Button-icon {
                 line-height: 15px;
                 height: 10px;


### PR DESCRIPTION
link style updates, link picker retrieval of existing url, remove sorting within grouping layout

| Q               | A
| --------------- | ---
| Bug fix?        | yes

#### What's in this Pull Request?

general styling fixes for different hub link layouts, correct the way the url is retrieved in the link picker to not require re-entry of existing url, and removing the sorting ability within the grouped links layout as sorting would not work and is not needed within groups.

Would prefer that there be a new dev branch for LinksAndHandlebars if possible to PR towards. General changes requested by Shire/Takeda, being shared here.