### PR TITLE
[ModernSearch] Fix documentcard grid

### DIFF
--- a/solutions/ModernSearch/react-search-refiners/spfx/package-lock.json
+++ b/solutions/ModernSearch/react-search-refiners/spfx/package-lock.json
@@ -1034,6 +1034,16 @@
                         "csstype": "^2.2.0"
                     }
                 },
+                "@uifabric/icons": {
+                    "version": "6.4.0",
+                    "resolved": "https://registry.npmjs.org/@uifabric/icons/-/icons-6.4.0.tgz",
+                    "integrity": "sha512-pbKu3OnWaRIeDqMFhicDrrcqicxNqoHpJpknZR9N2xxoPnYMnt2ZOhBNnAxoVVcxHlWkFNg0rvFrOAQGn+S5/Q==",
+                    "requires": {
+                        "@uifabric/set-version": ">=1.1.3 <2.0.0",
+                        "@uifabric/styling": ">=6.41.0 <7.0.0",
+                        "tslib": "^1.7.1"
+                    }
+                },
                 "office-ui-fabric-react": {
                     "version": "6.143.0",
                     "resolved": "https://registry.npmjs.org/office-ui-fabric-react/-/office-ui-fabric-react-6.143.0.tgz",
@@ -1664,6 +1674,52 @@
                         "@uifabric/utilities": ">=6.29.3 <7.0.0",
                         "prop-types": "^15.5.10",
                         "tslib": "^1.7.1"
+                    },
+                    "dependencies": {
+                        "@uifabric/icons": {
+                            "version": "6.5.5",
+                            "resolved": "https://registry.npmjs.org/@uifabric/icons/-/icons-6.5.5.tgz",
+                            "integrity": "sha512-cGjzdpT0jzQ2RJvzlCVTrewaHCi4rb+ZNL2LWoceMi+5h196Y32qJwKMsc0ggR6u5CjMrzBiAxUFNppBSCutdA==",
+                            "requires": {
+                                "@uifabric/set-version": "^1.1.3",
+                                "@uifabric/styling": "^6.50.7",
+                                "tslib": "^1.7.1"
+                            },
+                            "dependencies": {
+                                "@uifabric/merge-styles": {
+                                    "version": "6.19.4",
+                                    "resolved": "https://registry.npmjs.org/@uifabric/merge-styles/-/merge-styles-6.19.4.tgz",
+                                    "integrity": "sha512-bjQdDHxmRIZVPwL//MtErODhEfcRJ2y+zJXoIWNh3T8JfAepeRDdoJ/pGNnnyJxA/AHMtlWt0IgMaz150/nfAA==",
+                                    "requires": {
+                                        "@uifabric/set-version": "^1.1.3",
+                                        "tslib": "^1.7.1"
+                                    }
+                                },
+                                "@uifabric/styling": {
+                                    "version": "6.50.7",
+                                    "resolved": "https://registry.npmjs.org/@uifabric/styling/-/styling-6.50.7.tgz",
+                                    "integrity": "sha512-F2aBiB30ZiFxlZzy5hzLXODWOl6jySvPFAsoaTofk37xucHiunBLZYjX6WkfZrCWiyGPva+DLssNcwly9ZHVjg==",
+                                    "requires": {
+                                        "@microsoft/load-themed-styles": "^1.7.13",
+                                        "@uifabric/merge-styles": "^6.19.4",
+                                        "@uifabric/set-version": "^1.1.3",
+                                        "@uifabric/utilities": "^6.41.7",
+                                        "tslib": "^1.7.1"
+                                    }
+                                },
+                                "@uifabric/utilities": {
+                                    "version": "6.45.0",
+                                    "resolved": "https://registry.npmjs.org/@uifabric/utilities/-/utilities-6.45.0.tgz",
+                                    "integrity": "sha512-sC9etmDJ2kLV8409oaUVqxmMCU6IaBLtyvO6VQ/hFNo0r9Fqz2AgpqYaKRaKfXQvseqMJWTkYMXpovb2UfOpsg==",
+                                    "requires": {
+                                        "@uifabric/merge-styles": "^6.19.4",
+                                        "@uifabric/set-version": "^1.1.3",
+                                        "prop-types": "^15.5.10",
+                                        "tslib": "^1.7.1"
+                                    }
+                                }
+                            }
+                        }
                     }
                 }
             }
@@ -1771,6 +1827,52 @@
                         "@uifabric/utilities": ">=6.29.3 <7.0.0",
                         "prop-types": "^15.5.10",
                         "tslib": "^1.7.1"
+                    },
+                    "dependencies": {
+                        "@uifabric/icons": {
+                            "version": "6.5.5",
+                            "resolved": "https://registry.npmjs.org/@uifabric/icons/-/icons-6.5.5.tgz",
+                            "integrity": "sha512-cGjzdpT0jzQ2RJvzlCVTrewaHCi4rb+ZNL2LWoceMi+5h196Y32qJwKMsc0ggR6u5CjMrzBiAxUFNppBSCutdA==",
+                            "requires": {
+                                "@uifabric/set-version": "^1.1.3",
+                                "@uifabric/styling": "^6.50.7",
+                                "tslib": "^1.7.1"
+                            },
+                            "dependencies": {
+                                "@uifabric/merge-styles": {
+                                    "version": "6.19.4",
+                                    "resolved": "https://registry.npmjs.org/@uifabric/merge-styles/-/merge-styles-6.19.4.tgz",
+                                    "integrity": "sha512-bjQdDHxmRIZVPwL//MtErODhEfcRJ2y+zJXoIWNh3T8JfAepeRDdoJ/pGNnnyJxA/AHMtlWt0IgMaz150/nfAA==",
+                                    "requires": {
+                                        "@uifabric/set-version": "^1.1.3",
+                                        "tslib": "^1.7.1"
+                                    }
+                                },
+                                "@uifabric/styling": {
+                                    "version": "6.50.7",
+                                    "resolved": "https://registry.npmjs.org/@uifabric/styling/-/styling-6.50.7.tgz",
+                                    "integrity": "sha512-F2aBiB30ZiFxlZzy5hzLXODWOl6jySvPFAsoaTofk37xucHiunBLZYjX6WkfZrCWiyGPva+DLssNcwly9ZHVjg==",
+                                    "requires": {
+                                        "@microsoft/load-themed-styles": "^1.7.13",
+                                        "@uifabric/merge-styles": "^6.19.4",
+                                        "@uifabric/set-version": "^1.1.3",
+                                        "@uifabric/utilities": "^6.41.7",
+                                        "tslib": "^1.7.1"
+                                    }
+                                },
+                                "@uifabric/utilities": {
+                                    "version": "6.45.0",
+                                    "resolved": "https://registry.npmjs.org/@uifabric/utilities/-/utilities-6.45.0.tgz",
+                                    "integrity": "sha512-sC9etmDJ2kLV8409oaUVqxmMCU6IaBLtyvO6VQ/hFNo0r9Fqz2AgpqYaKRaKfXQvseqMJWTkYMXpovb2UfOpsg==",
+                                    "requires": {
+                                        "@uifabric/merge-styles": "^6.19.4",
+                                        "@uifabric/set-version": "^1.1.3",
+                                        "prop-types": "^15.5.10",
+                                        "tslib": "^1.7.1"
+                                    }
+                                }
+                            }
+                        }
                     }
                 }
             }
@@ -1896,6 +1998,52 @@
                         "@uifabric/utilities": ">=6.29.3 <7.0.0",
                         "prop-types": "^15.5.10",
                         "tslib": "^1.7.1"
+                    },
+                    "dependencies": {
+                        "@uifabric/icons": {
+                            "version": "6.5.5",
+                            "resolved": "https://registry.npmjs.org/@uifabric/icons/-/icons-6.5.5.tgz",
+                            "integrity": "sha512-cGjzdpT0jzQ2RJvzlCVTrewaHCi4rb+ZNL2LWoceMi+5h196Y32qJwKMsc0ggR6u5CjMrzBiAxUFNppBSCutdA==",
+                            "requires": {
+                                "@uifabric/set-version": "^1.1.3",
+                                "@uifabric/styling": "^6.50.7",
+                                "tslib": "^1.7.1"
+                            },
+                            "dependencies": {
+                                "@uifabric/merge-styles": {
+                                    "version": "6.19.4",
+                                    "resolved": "https://registry.npmjs.org/@uifabric/merge-styles/-/merge-styles-6.19.4.tgz",
+                                    "integrity": "sha512-bjQdDHxmRIZVPwL//MtErODhEfcRJ2y+zJXoIWNh3T8JfAepeRDdoJ/pGNnnyJxA/AHMtlWt0IgMaz150/nfAA==",
+                                    "requires": {
+                                        "@uifabric/set-version": "^1.1.3",
+                                        "tslib": "^1.7.1"
+                                    }
+                                },
+                                "@uifabric/styling": {
+                                    "version": "6.50.7",
+                                    "resolved": "https://registry.npmjs.org/@uifabric/styling/-/styling-6.50.7.tgz",
+                                    "integrity": "sha512-F2aBiB30ZiFxlZzy5hzLXODWOl6jySvPFAsoaTofk37xucHiunBLZYjX6WkfZrCWiyGPva+DLssNcwly9ZHVjg==",
+                                    "requires": {
+                                        "@microsoft/load-themed-styles": "^1.7.13",
+                                        "@uifabric/merge-styles": "^6.19.4",
+                                        "@uifabric/set-version": "^1.1.3",
+                                        "@uifabric/utilities": "^6.41.7",
+                                        "tslib": "^1.7.1"
+                                    }
+                                },
+                                "@uifabric/utilities": {
+                                    "version": "6.45.0",
+                                    "resolved": "https://registry.npmjs.org/@uifabric/utilities/-/utilities-6.45.0.tgz",
+                                    "integrity": "sha512-sC9etmDJ2kLV8409oaUVqxmMCU6IaBLtyvO6VQ/hFNo0r9Fqz2AgpqYaKRaKfXQvseqMJWTkYMXpovb2UfOpsg==",
+                                    "requires": {
+                                        "@uifabric/merge-styles": "^6.19.4",
+                                        "@uifabric/set-version": "^1.1.3",
+                                        "prop-types": "^15.5.10",
+                                        "tslib": "^1.7.1"
+                                    }
+                                }
+                            }
+                        }
                     }
                 }
             }
@@ -2040,6 +2188,52 @@
                         "@uifabric/utilities": ">=6.29.3 <7.0.0",
                         "prop-types": "^15.5.10",
                         "tslib": "^1.7.1"
+                    },
+                    "dependencies": {
+                        "@uifabric/icons": {
+                            "version": "6.5.5",
+                            "resolved": "https://registry.npmjs.org/@uifabric/icons/-/icons-6.5.5.tgz",
+                            "integrity": "sha512-cGjzdpT0jzQ2RJvzlCVTrewaHCi4rb+ZNL2LWoceMi+5h196Y32qJwKMsc0ggR6u5CjMrzBiAxUFNppBSCutdA==",
+                            "requires": {
+                                "@uifabric/set-version": "^1.1.3",
+                                "@uifabric/styling": "^6.50.7",
+                                "tslib": "^1.7.1"
+                            },
+                            "dependencies": {
+                                "@uifabric/merge-styles": {
+                                    "version": "6.19.4",
+                                    "resolved": "https://registry.npmjs.org/@uifabric/merge-styles/-/merge-styles-6.19.4.tgz",
+                                    "integrity": "sha512-bjQdDHxmRIZVPwL//MtErODhEfcRJ2y+zJXoIWNh3T8JfAepeRDdoJ/pGNnnyJxA/AHMtlWt0IgMaz150/nfAA==",
+                                    "requires": {
+                                        "@uifabric/set-version": "^1.1.3",
+                                        "tslib": "^1.7.1"
+                                    }
+                                },
+                                "@uifabric/styling": {
+                                    "version": "6.50.7",
+                                    "resolved": "https://registry.npmjs.org/@uifabric/styling/-/styling-6.50.7.tgz",
+                                    "integrity": "sha512-F2aBiB30ZiFxlZzy5hzLXODWOl6jySvPFAsoaTofk37xucHiunBLZYjX6WkfZrCWiyGPva+DLssNcwly9ZHVjg==",
+                                    "requires": {
+                                        "@microsoft/load-themed-styles": "^1.7.13",
+                                        "@uifabric/merge-styles": "^6.19.4",
+                                        "@uifabric/set-version": "^1.1.3",
+                                        "@uifabric/utilities": "^6.41.7",
+                                        "tslib": "^1.7.1"
+                                    }
+                                },
+                                "@uifabric/utilities": {
+                                    "version": "6.45.0",
+                                    "resolved": "https://registry.npmjs.org/@uifabric/utilities/-/utilities-6.45.0.tgz",
+                                    "integrity": "sha512-sC9etmDJ2kLV8409oaUVqxmMCU6IaBLtyvO6VQ/hFNo0r9Fqz2AgpqYaKRaKfXQvseqMJWTkYMXpovb2UfOpsg==",
+                                    "requires": {
+                                        "@uifabric/merge-styles": "^6.19.4",
+                                        "@uifabric/set-version": "^1.1.3",
+                                        "prop-types": "^15.5.10",
+                                        "tslib": "^1.7.1"
+                                    }
+                                }
+                            }
+                        }
                     }
                 }
             }
@@ -2130,6 +2324,56 @@
                         "@uifabric/utilities": ">=6.29.3 <7.0.0",
                         "prop-types": "^15.5.10",
                         "tslib": "^1.7.1"
+                    },
+                    "dependencies": {
+                        "@uifabric/icons": {
+                            "version": "6.5.5",
+                            "resolved": "https://registry.npmjs.org/@uifabric/icons/-/icons-6.5.5.tgz",
+                            "integrity": "sha512-cGjzdpT0jzQ2RJvzlCVTrewaHCi4rb+ZNL2LWoceMi+5h196Y32qJwKMsc0ggR6u5CjMrzBiAxUFNppBSCutdA==",
+                            "dev": true,
+                            "requires": {
+                                "@uifabric/set-version": "^1.1.3",
+                                "@uifabric/styling": "^6.50.7",
+                                "tslib": "^1.7.1"
+                            },
+                            "dependencies": {
+                                "@uifabric/merge-styles": {
+                                    "version": "6.19.4",
+                                    "resolved": "https://registry.npmjs.org/@uifabric/merge-styles/-/merge-styles-6.19.4.tgz",
+                                    "integrity": "sha512-bjQdDHxmRIZVPwL//MtErODhEfcRJ2y+zJXoIWNh3T8JfAepeRDdoJ/pGNnnyJxA/AHMtlWt0IgMaz150/nfAA==",
+                                    "dev": true,
+                                    "requires": {
+                                        "@uifabric/set-version": "^1.1.3",
+                                        "tslib": "^1.7.1"
+                                    }
+                                },
+                                "@uifabric/styling": {
+                                    "version": "6.50.7",
+                                    "resolved": "https://registry.npmjs.org/@uifabric/styling/-/styling-6.50.7.tgz",
+                                    "integrity": "sha512-F2aBiB30ZiFxlZzy5hzLXODWOl6jySvPFAsoaTofk37xucHiunBLZYjX6WkfZrCWiyGPva+DLssNcwly9ZHVjg==",
+                                    "dev": true,
+                                    "requires": {
+                                        "@microsoft/load-themed-styles": "^1.7.13",
+                                        "@uifabric/merge-styles": "^6.19.4",
+                                        "@uifabric/set-version": "^1.1.3",
+                                        "@uifabric/utilities": "^6.41.7",
+                                        "tslib": "^1.7.1"
+                                    }
+                                },
+                                "@uifabric/utilities": {
+                                    "version": "6.45.0",
+                                    "resolved": "https://registry.npmjs.org/@uifabric/utilities/-/utilities-6.45.0.tgz",
+                                    "integrity": "sha512-sC9etmDJ2kLV8409oaUVqxmMCU6IaBLtyvO6VQ/hFNo0r9Fqz2AgpqYaKRaKfXQvseqMJWTkYMXpovb2UfOpsg==",
+                                    "dev": true,
+                                    "requires": {
+                                        "@uifabric/merge-styles": "^6.19.4",
+                                        "@uifabric/set-version": "^1.1.3",
+                                        "prop-types": "^15.5.10",
+                                        "tslib": "^1.7.1"
+                                    }
+                                }
+                            }
+                        }
                     }
                 },
                 "prop-types": {
@@ -3067,6 +3311,58 @@
             "resolved": "https://registry.npmjs.org/@types/z-schema/-/z-schema-3.16.31.tgz",
             "integrity": "sha1-LrHQCl5Ow/pYx2r94S4YK2bcXBw="
         },
+        "@uifabric/file-type-icons": {
+            "version": "7.1.1",
+            "resolved": "https://registry.npmjs.org/@uifabric/file-type-icons/-/file-type-icons-7.1.1.tgz",
+            "integrity": "sha512-lkEuI1ovnf8ewlaig1UUnZCB1vSGl0YcKSgKEYYDct4y9gKlFLuZKuvbuN2KEMrUQX0nijqmI4IOWwjYH8SvgQ==",
+            "requires": {
+                "@uifabric/set-version": "^7.0.2",
+                "@uifabric/styling": "^7.7.2",
+                "tslib": "^1.7.1"
+            },
+            "dependencies": {
+                "@uifabric/merge-styles": {
+                    "version": "7.7.0",
+                    "resolved": "https://registry.npmjs.org/@uifabric/merge-styles/-/merge-styles-7.7.0.tgz",
+                    "integrity": "sha512-VMLSHKNp4dFDOZTdXeXhNvkrdmxjTwP4MaUf6yLeMkD1qf36/uFAN4nQ7jVAr6RC5cVMklmxN6FtNj+6+bHGfA==",
+                    "requires": {
+                        "@uifabric/set-version": "^7.0.2",
+                        "tslib": "^1.7.1"
+                    }
+                },
+                "@uifabric/set-version": {
+                    "version": "7.0.2",
+                    "resolved": "https://registry.npmjs.org/@uifabric/set-version/-/set-version-7.0.2.tgz",
+                    "integrity": "sha512-3mQp7gqPOqphwX74j+N/lJEFeivKPv8ryY9QFXUxVPnrXNwpIkDW9Wk6CPqArzgGvQngRRKYD/PcyP5iuHN52A==",
+                    "requires": {
+                        "tslib": "^1.7.1"
+                    }
+                },
+                "@uifabric/styling": {
+                    "version": "7.7.2",
+                    "resolved": "https://registry.npmjs.org/@uifabric/styling/-/styling-7.7.2.tgz",
+                    "integrity": "sha512-5xQbz5r4+XeWjb1omHara/1Hdk+dsNSUkZAw6sp/tnv/cGFea4+hMuSmSaTG6T78Osiy59UG+qw7Ax/spfr2EQ==",
+                    "requires": {
+                        "@microsoft/load-themed-styles": "^1.7.13",
+                        "@uifabric/merge-styles": "^7.7.0",
+                        "@uifabric/set-version": "^7.0.2",
+                        "@uifabric/utilities": "^7.2.0",
+                        "tslib": "^1.7.1"
+                    }
+                },
+                "@uifabric/utilities": {
+                    "version": "7.5.0",
+                    "resolved": "https://registry.npmjs.org/@uifabric/utilities/-/utilities-7.5.0.tgz",
+                    "integrity": "sha512-h9XwZVaKyLN3Ss4G+bXFWsmCzExID/SKbO64XPjsCIhuxVYsTg6/hDrvyU4TCEx06/ehXfdHRmyjCYL1PNdDMg==",
+                    "requires": {
+                        "@uifabric/merge-styles": "^7.7.0",
+                        "@uifabric/set-version": "^7.0.2",
+                        "prop-types": "^15.5.10",
+                        "tslib": "^1.7.1"
+                    }
+                }
+            }
+        },
         "@uifabric/foundation": {
             "version": "0.8.2",
             "resolved": "https://registry.npmjs.org/@uifabric/foundation/-/foundation-0.8.2.tgz",
@@ -3092,13 +3388,55 @@
             }
         },
         "@uifabric/icons": {
-            "version": "6.4.0",
-            "resolved": "https://registry.npmjs.org/@uifabric/icons/-/icons-6.4.0.tgz",
-            "integrity": "sha512-pbKu3OnWaRIeDqMFhicDrrcqicxNqoHpJpknZR9N2xxoPnYMnt2ZOhBNnAxoVVcxHlWkFNg0rvFrOAQGn+S5/Q==",
+            "version": "7.3.0",
+            "resolved": "https://registry.npmjs.org/@uifabric/icons/-/icons-7.3.0.tgz",
+            "integrity": "sha512-wbcR8fJce20sPjsK2bbTC/cAZfAOFuE4dd4LHw194+8H+/dqotsowrQVp5Lu8aaHGQk+fXoiZmUy30WA9cAG4Q==",
             "requires": {
-                "@uifabric/set-version": ">=1.1.3 <2.0.0",
-                "@uifabric/styling": ">=6.41.0 <7.0.0",
+                "@uifabric/set-version": "^7.0.2",
+                "@uifabric/styling": "^7.7.1",
                 "tslib": "^1.7.1"
+            },
+            "dependencies": {
+                "@uifabric/merge-styles": {
+                    "version": "7.7.0",
+                    "resolved": "https://registry.npmjs.org/@uifabric/merge-styles/-/merge-styles-7.7.0.tgz",
+                    "integrity": "sha512-VMLSHKNp4dFDOZTdXeXhNvkrdmxjTwP4MaUf6yLeMkD1qf36/uFAN4nQ7jVAr6RC5cVMklmxN6FtNj+6+bHGfA==",
+                    "requires": {
+                        "@uifabric/set-version": "^7.0.2",
+                        "tslib": "^1.7.1"
+                    }
+                },
+                "@uifabric/set-version": {
+                    "version": "7.0.2",
+                    "resolved": "https://registry.npmjs.org/@uifabric/set-version/-/set-version-7.0.2.tgz",
+                    "integrity": "sha512-3mQp7gqPOqphwX74j+N/lJEFeivKPv8ryY9QFXUxVPnrXNwpIkDW9Wk6CPqArzgGvQngRRKYD/PcyP5iuHN52A==",
+                    "requires": {
+                        "tslib": "^1.7.1"
+                    }
+                },
+                "@uifabric/styling": {
+                    "version": "7.7.2",
+                    "resolved": "https://registry.npmjs.org/@uifabric/styling/-/styling-7.7.2.tgz",
+                    "integrity": "sha512-5xQbz5r4+XeWjb1omHara/1Hdk+dsNSUkZAw6sp/tnv/cGFea4+hMuSmSaTG6T78Osiy59UG+qw7Ax/spfr2EQ==",
+                    "requires": {
+                        "@microsoft/load-themed-styles": "^1.7.13",
+                        "@uifabric/merge-styles": "^7.7.0",
+                        "@uifabric/set-version": "^7.0.2",
+                        "@uifabric/utilities": "^7.2.0",
+                        "tslib": "^1.7.1"
+                    }
+                },
+                "@uifabric/utilities": {
+                    "version": "7.5.0",
+                    "resolved": "https://registry.npmjs.org/@uifabric/utilities/-/utilities-7.5.0.tgz",
+                    "integrity": "sha512-h9XwZVaKyLN3Ss4G+bXFWsmCzExID/SKbO64XPjsCIhuxVYsTg6/hDrvyU4TCEx06/ehXfdHRmyjCYL1PNdDMg==",
+                    "requires": {
+                        "@uifabric/merge-styles": "^7.7.0",
+                        "@uifabric/set-version": "^7.0.2",
+                        "prop-types": "^15.5.10",
+                        "tslib": "^1.7.1"
+                    }
+                }
             }
         },
         "@uifabric/merge-styles": {

--- a/solutions/ModernSearch/react-search-refiners/spfx/src/services/TemplateService/DocumentCardComponent/DocumentCardComponent.tsx
+++ b/solutions/ModernSearch/react-search-refiners/spfx/src/services/TemplateService/DocumentCardComponent/DocumentCardComponent.tsx
@@ -112,7 +112,7 @@ export class DocumentCardComponent extends React.Component<IDocumentCardComponen
                     previewImageSrc: processedProps.previewImage,
                     imageFit: ImageFit.centerCover,
                     iconSrc: globalSettings.icons[iconProps.iconName].code.props.src,
-                    //width: 318,
+                    width: 318,
                     height: 196,
                 }
             ],

--- a/solutions/ModernSearch/react-search-refiners/spfx/src/services/TemplateService/templates/layouts/people.html
+++ b/solutions/ModernSearch/react-search-refiners/spfx/src/services/TemplateService/templates/layouts/people.html
@@ -13,20 +13,18 @@
                     <label class="ms-fontWeight-semibold">{{getCountMessage totalRows keywords}}</label>
                 </div>
                 {{/if}}
-                <div class="ms-Grid">
-                    <div class="ms-Grid-row">
-                        {{#each items as |item|}}
-                        <div class="ms-Grid-col ms-sm12 ms-md12 ms-lg12">
-                            {{#> resultTypes item=item}}
-                                <div class="personaCard">
-                                    {{#with (split AccountName '|')}}
-                                            <persona-card fields-configuration="{{JSONstringify ../../../peopleFields}}" item="{{JSONstringify item}}" persona-size="{{../../../personaSize}}" />
-                                    {{/with}}
-                                </div>
-                            {{/resultTypes}}
-                        </div>
-                        {{/each}}
+                <div class="document-card-container">
+                    {{#each items as |item|}}
+                    <div class="document-card-item">
+                        {{#> resultTypes item=item}}
+                            <div class="personaCard">
+                                {{#with (split AccountName '|')}}
+                                        <persona-card fields-configuration="{{JSONstringify ../../../peopleFields}}" item="{{JSONstringify item}}" persona-size="{{../../../personaSize}}" />
+                                {{/with}}
+                            </div>
+                        {{/resultTypes}}
                     </div>
+                    {{/each}}
                 </div>
             </div>
         </div>
@@ -40,14 +38,12 @@
                         <span class="shimmer line" style="width: 20%"></span>
                     </div>
                 {{/if}}
-                <div class="ms-Grid"> 
-                    <div class="ms-Grid-row">
-                        {{#times maxResultsCount}}
-                            <div class="ms-Grid-col ms-sm12 ms-md12 ms-lg12">
-                                <persona-card-shimmers persona-size="{{@root.personaSize}}"></persona-card-shimmers>
-                            </div>
-                        {{/times}}
-                    </div>
+                <div class="document-card-container">
+                    {{#times maxResultsCount}}
+                        <div class="document-card-item">
+                            <persona-card-shimmers persona-size="{{@root.personaSize}}"></persona-card-shimmers>
+                        </div>
+                    {{/times}}
                 </div>
             </div>
         </div>

--- a/solutions/ModernSearch/react-search-refiners/spfx/src/services/TemplateService/templates/layouts/tiles.html
+++ b/solutions/ModernSearch/react-search-refiners/spfx/src/services/TemplateService/templates/layouts/tiles.html
@@ -1,5 +1,4 @@
 <content id="template">
-
     <div class="template_root">
         <div class="template_defaultCard">
             {{#if showResultsCount}}
@@ -7,21 +6,19 @@
                 <label class="ms-fontWeight-semibold">{{getCountMessage totalRows keywords}}</label>
             </div>
             {{/if}}
-            <div class="ms-Grid">
-                <div class="ms-Grid-row">
-                    {{#each items as |item|}}
-                    <div class="ms-Grid-col ms-sm12 ms-md6 ms-lg4">
-                        {{#> resultTypes item=item}}
-                            {{!-- The block below will be used as default item template if no result types matched --}}
-                            {{#eq item.contentclass 'STS_ListItem_851'}}
-                                <video-card item="{{JSONstringify item}}" fields-configuration="{{JSONstringify @root.documentCardFields}}" enable-preview="{{@root.enablePreview}}" show-file-icon="{{@root.showFileIcon}}" is-compact="{{@root.isCompact}}"></video-card>
-                            {{else}}
-                                <document-card item="{{JSONstringify item}}" fields-configuration="{{JSONstringify @root.documentCardFields}}" enable-preview="{{@root.enablePreview}}" show-file-icon="{{@root.showFileIcon}}" is-compact="{{@root.isCompact}}"></document-card>
-                            {{/eq}} 
-                        {{/resultTypes}}
-                    </div>
-                    {{/each}}
+            <div class="document-card-container">
+                {{#each items as |item|}}
+                <div class="document-card-item">
+                    {{#> resultTypes item=item}}
+                        {{!-- The block below will be used as default item template if no result types matched --}}
+                        {{#eq item.contentclass 'STS_ListItem_851'}}
+                            <video-card item="{{JSONstringify item}}" fields-configuration="{{JSONstringify @root.documentCardFields}}" enable-preview="{{@root.enablePreview}}" show-file-icon="{{@root.showFileIcon}}" is-compact="{{@root.isCompact}}"></video-card>
+                        {{else}}
+                            <document-card item="{{JSONstringify item}}" fields-configuration="{{JSONstringify @root.documentCardFields}}" enable-preview="{{@root.enablePreview}}" show-file-icon="{{@root.showFileIcon}}" is-compact="{{@root.isCompact}}"></document-card>
+                        {{/eq}} 
+                    {{/resultTypes}}
                 </div>
+                {{/each}}
             </div>
         </div>
     </div>
@@ -35,14 +32,12 @@
                     <span class="shimmer line" style="width: 20%"></span>
                 </div>
             {{/if}}
-            <div class="ms-Grid"> 
-                <div class="ms-Grid-row">
-                    {{#times maxResultsCount}}
-                        <div class="ms-Grid-col ms-sm12 ms-md6 ms-lg4">
-                            <document-card-shimmers is-compact="{{@root.isCompact}}"></document-card-shimmers>
-                        </div>
-                    {{/times}}
-                </div>
+            <div class="document-card-container"> 
+                {{#times maxResultsCount}}
+                    <div class="document-card-item">
+                        <document-card-shimmers is-compact="{{@root.isCompact}}"></document-card-shimmers>
+                    </div>
+                {{/times}}
             </div>
         </div>
     </div>

--- a/solutions/ModernSearch/react-search-refiners/spfx/src/webparts/searchResults/components/Layouts/SearchResultsTemplate.scss
+++ b/solutions/ModernSearch/react-search-refiners/spfx/src/webparts/searchResults/components/Layouts/SearchResultsTemplate.scss
@@ -121,9 +121,19 @@
         }
     }
     
-    // Legacy CSS for backward compatibility, now replaced by Office UI Fabric controls
     .template_defaultCard {
+        .document-card-container {
+            display: flex;
+            flex-flow: row wrap;
+            justify-content: left;
+        }
 
+        .document-card-item {
+            margin-right: 15px;
+            flex: 0 0 345px;
+        }
+
+        // Legacy CSS for backward compatibility, now replaced by Office UI Fabric controls
         .singleCard {
             margin: 10px;
             border: 1px solid #eaeaea;


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes

#### What's in this Pull Request?

- Switch from Office UI Grid System (ms-Grid) to Flexbox. ms-Grid decides sizes based on full screen and not on container space, as a result "big screen but small column" == "still using spacing for the big screen thus showing 3 columns of cards instead of just one".
Fixed for document card and people card
- Undid a change made by @wobba to put back the width on the preview image for document card, otherwise nothing shows in the small version of the card. Was there a reason you removed it in the first place?