### PR TITLE
[ModernSearch] Improve fixed interval regex

### DIFF
--- a/solutions/ModernSearch/react-search-refiners/spfx/src/services/SearchService/SearchService.ts
+++ b/solutions/ModernSearch/react-search-refiners/spfx/src/services/SearchService/SearchService.ts
@@ -147,12 +147,9 @@ class SearchService implements ISearchService {
             // Get the refiners order specified in the property pane
             sortedRefiners = this.refiners.map(e => e.refinerName);
             searchQuery.Refiners = sortedRefiners.join(',');
-
             
-            const refinableDate = /(RefinableDate\d+)|(LastModifiedTime)|(Created)|/g;
-
-            const matches = searchQuery.Refiners.match(refinableDate);
-            if (matches) {
+            const refinableDate = /(RefinableDate\d+)(?=,|$)|(LastModifiedTime)(?=,|$)|(LastModifiedTimeForRetention)(?=,|$)|(Created)(?=,|$)/g;
+            if (refinableDate.test(searchQuery.Refiners)) {
                 // set refiner spec intervals to be used for fixed interval template - and which makes more sense overall
                 await Loader.LoadHandlebarsHelpers();
 
@@ -162,9 +159,7 @@ class SearchService implements ISearchService {
                 let threeMonthsAgo = this._getISOString("months", 3);
                 let yearAgo = this._getISOString("years", 1);  
 
-                matches.map(match => {
-                    searchQuery.Refiners = searchQuery.Refiners.replace(match, `${match}(discretize=manual/${yearAgo}/${threeMonthsAgo}/${monthAgo}/${weekAgo}/${yesterDay})`);
-                });
+                searchQuery.Refiners = searchQuery.Refiners.replace(refinableDate, `$&(discretize=manual/${yearAgo}/${threeMonthsAgo}/${monthAgo}/${weekAgo}/${yesterDay})`);
             }
         }
 

--- a/solutions/ModernSearch/react-search-refiners/spfx/src/webparts/searchRefiners/components/Templates/FixedDateRange/FixedDateRangeTemplate.tsx
+++ b/solutions/ModernSearch/react-search-refiners/spfx/src/webparts/searchRefiners/components/Templates/FixedDateRange/FixedDateRangeTemplate.tsx
@@ -54,7 +54,7 @@ export default class FixedDateRangeTemplate extends React.Component<IFixedDateRa
         if (!this.state.haveMoment) return null;
 
         if (this.props.refinementResult.Values.length !== 6) {
-            return <div>This template only works for Created, LastModifiedTime and RefinableDateXX properties</div>;
+            return <div>This template only works for Created, LastModifiedTime, LastModifiedTimeForRetention and RefinableDateXX properties</div>;
         }
 
         let options =


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes

- Removed ending | in regex that broke matching, resulting in the first refiner to be omitted
- Improved regex to match full words (if they are at the end of the line OR are followed by comma), with lookaheads
- Added support for LastModifiedTimeForRetention managed property
- Adjust match replacement to use the actual regex instead of string matches, as that resulted in wrong replacements when LastModifiedTime and LastModifiedTimeForRetention existed in the string (for example)