### PR TITLE
[ModernSearch] Improve Date Interval refiner template

### DIFF
--- a/solutions/ModernSearch/react-search-refiners/spfx/tsconfig.json
+++ b/solutions/ModernSearch/react-search-refiners/spfx/tsconfig.json
@@ -24,6 +24,7 @@
     ],
     "lib": [
       "es5",
+      "es6",
       "dom",
       "es2015.collection"
     ]


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes

#### What's in this Pull Request?
- Fix constant "flashing" of refiner options in the Date Interval template
- Fix for losing state when collapsing and expanding Date Interval refiner
- Fix for usage in LinkPanel where a filter could not be removed from the list of applied filters